### PR TITLE
Update Build Tools and Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,6 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
-org.gradle.java.home=C:\\Program Files\\Java\\jdk1.8.0_102
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
*Update Build Tools to 2.3.3.
*Update Gradle properties to remove specified Java JDK location. This allows the project to compile if the user has set the JDK in an alternate location.