### PR TITLE
BUG : The specified child already has a parent. You must call removeView() on the child's parent first.

### DIFF
--- a/holdingbutton/src/main/java/com/dewarder/holdinglibrary/HoldingButtonLayout.java
+++ b/holdingbutton/src/main/java/com/dewarder/holdinglibrary/HoldingButtonLayout.java
@@ -266,6 +266,9 @@ public class HoldingButtonLayout extends FrameLayout {
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
+        if (mHoldingCircle.getParent() != null){
+            ((ViewGroup)mHoldingCircle.getParent()).removeView(mHoldingCircle);
+        }
         getDecorView().addView(mHoldingCircle, mHoldingDrawable.getIntrinsicWidth(), mHoldingDrawable.getIntrinsicHeight());
     }
 


### PR DESCRIPTION
In my project, I use a swipe back library.When I swipe back I got the exception below : 
**The specified child already has a parent. You must call removeView() on the child's parent first.**
I found it and fixed, I have tried in my project and there was no such exception anymore.
So I hope you can merge it and create a new tag. 